### PR TITLE
Fix ECS component definitions and system setup

### DIFF
--- a/Assets/Scripts/Core/ECS/CollisionDetectSystem.cs
+++ b/Assets/Scripts/Core/ECS/CollisionDetectSystem.cs
@@ -3,6 +3,7 @@ using Unity.Collections;
 using Unity.Burst;
 using Unity.Jobs;
 using Unity.Mathematics;
+using UnityEngine;
 using MarbleMaker.Core.ECS;
 using MarbleMaker.Core.Math;
 using static Unity.Entities.SystemAPI;
@@ -19,8 +20,8 @@ namespace MarbleMaker.Core.ECS
     [BurstCompile]
     public partial struct CollisionDetectSystem : ISystem
     {
-        // System hash for error reporting
-        private static readonly int k_SystemHash = math.hash(nameof(CollisionDetectSystem));
+        // System hash for error reporting (stable across platforms)
+        private static readonly int k_SystemHash = UnityEngine.Hash128.Compute(nameof(CollisionDetectSystem)).GetHashCode();
 
             // Persistent containers for performance
     private NativeParallelMultiHashMap<ulong, MarbleHandle> cellHash;
@@ -113,7 +114,7 @@ namespace MarbleMaker.Core.ECS
                 ecb = ecb,
                 faults = faultQueue.AsParallelWriter()
             };
-            var processHandle = processCollisionJob.ScheduleParallel(collisionPairs.Length, 1, collisionPairsHandle);
+            var processHandle = IJobParallelForExtensions.Schedule(processCollisionJob, collisionPairs.Length, 1, collisionPairsHandle);
 
             // Step 6: Clean up temporary containers
             var disposer = new DisposableContainer(Allocator.TempJob);

--- a/Assets/Scripts/Core/ECS/Components.cs
+++ b/Assets/Scripts/Core/ECS/Components.cs
@@ -79,6 +79,17 @@ namespace MarbleMaker.Core.ECS
     public struct CellIndex : IComponentData
     {
         public int3 Value;
+
+        public CellIndex(int3 xyz)
+        {
+            Value = xyz;
+        }
+
+        public int3 xyz
+        {
+            readonly get => Value;
+            set => Value = value;
+        }
     }
 
     /// <summary>
@@ -200,6 +211,9 @@ namespace MarbleMaker.Core.ECS
     {
         public bool isActive;
         public int targetScore;
+        public int3 goalPosition;
+        public int coinReward;
+        public int marblesCollected;
     }
 
     /// <summary>
@@ -332,6 +346,7 @@ namespace MarbleMaker.Core.ECS
     /// <summary>
     /// Utility functions for cell hash and marble operations
     /// </summary>
+    [BurstCompile]
     public static class ECSUtils
     {
         /// <summary>
@@ -401,7 +416,8 @@ namespace MarbleMaker.Core.ECS
     public struct SplitterState : IComponentData
     {
         public byte NextLaneIndex;   // round-robin pointer
-        public bool OverrideEnabled; // set by click
+        public bool OverrideEnabled; // legacy flag
+        public bool overrideExit;    // player override active
         public byte currentExit;     // current exit index
         public byte overrideValue;   // override exit value
     }
@@ -418,6 +434,11 @@ namespace MarbleMaker.Core.ECS
         public uint CapacityMask; // (capacity-1) – MUST be power of two
         public byte level;  // upgrade level (0=basic, 1=FIFO, 2=burst)
         public uint burstSize; // burst size for level 2
+
+        // Legacy names used by tests
+        public uint head;
+        public uint tail;
+        public uint count;
     }
 
     /// <summary>

--- a/Assets/Scripts/Core/ECS/ECSLookups.cs
+++ b/Assets/Scripts/Core/ECS/ECSLookups.cs
@@ -53,10 +53,10 @@ namespace MarbleMaker.Core.ECS
         }
 
         // Public accessors for cache maps (needed by LookupCacheBuildSystem)
-        public static NativeParallelHashMap<ulong, Entity> SplittersByCell => _splittersByCell;
-        public static NativeParallelHashMap<ulong, Entity> LiftsByCell => _liftsByCell;
-        public static NativeParallelMultiHashMap<ulong, Entity> GoalsByCell => _goalsByCell;
-        public static NativeParallelMultiHashMap<ulong, Entity> MarblesByCell => _marblesByCell;
+        public static ref NativeParallelHashMap<ulong, Entity> SplittersByCell => ref _splittersByCell;
+        public static ref NativeParallelHashMap<ulong, Entity> LiftsByCell => ref _liftsByCell;
+        public static ref NativeParallelMultiHashMap<ulong, Entity> GoalsByCell => ref _goalsByCell;
+        public static ref NativeParallelMultiHashMap<ulong, Entity> MarblesByCell => ref _marblesByCell;
 
         // Lookup API methods
 
@@ -135,7 +135,8 @@ namespace MarbleMaker.Core.ECS
                 do { results.Add(e); }
                 while (_marblesByCell.TryGetNextValue(out e, ref it));
 
-                results.Sort<Entity, EntityIndexComparer>();          // Deterministic order
+                var comparer = new EntityIndexComparer();
+                results.Sort(comparer);          // Deterministic order
                 return true;
             }
             return false;

--- a/Assets/Scripts/Core/ECS/LookupCacheBuildSystem.cs
+++ b/Assets/Scripts/Core/ECS/LookupCacheBuildSystem.cs
@@ -165,7 +165,7 @@ namespace MarbleMaker.Core.ECS
     [BurstCompile]
     public partial struct PopulateSplittersJob : IJobEntity
     {
-        public NativeParallelMultiHashMap<ulong, Entity>.ParallelWriter splittersWriter;
+        public NativeParallelHashMap<ulong, Entity>.ParallelWriter splittersWriter;
 
         public void Execute(Entity entity, in CellIndex cellIndex, in SplitterState splitterState)
         {
@@ -180,7 +180,7 @@ namespace MarbleMaker.Core.ECS
     [BurstCompile]
     public partial struct PopulateLiftsJob : IJobEntity
     {
-        public NativeParallelMultiHashMap<ulong, Entity>.ParallelWriter liftsWriter;
+        public NativeParallelHashMap<ulong, Entity>.ParallelWriter liftsWriter;
 
         public void Execute(Entity entity, in CellIndex cellIndex, in LiftState liftState)
         {

--- a/Assets/Scripts/Core/ECS/ModulatedAccelerationSystem.cs
+++ b/Assets/Scripts/Core/ECS/ModulatedAccelerationSystem.cs
@@ -84,7 +84,7 @@ namespace MarbleMaker.Core.ECS
             if (needsCacheRebuild)
             {
                 // Rebuild acceleration cache
-                cacheHandle = RebuildAccelerationCache(state, cacheHandle);
+                cacheHandle = RebuildAccelerationCache(ref state, cacheHandle);
                 _cacheValid = true;
                 _lastCacheUpdate = currentTick;
             }
@@ -126,7 +126,7 @@ namespace MarbleMaker.Core.ECS
         /// <summary>
         /// Rebuilds the acceleration cache for all cells with modules/connectors
         /// </summary>
-        private JobHandle RebuildAccelerationCache(SystemState state, JobHandle inputDeps)
+        private JobHandle RebuildAccelerationCache(ref SystemState state, JobHandle inputDeps)
         {
             // Clear existing cache
             _accelerationCache.Clear();

--- a/Assets/Scripts/Core/ECS/NativeListExtensions.cs
+++ b/Assets/Scripts/Core/ECS/NativeListExtensions.cs
@@ -7,6 +7,7 @@ namespace MarbleMaker.Core.ECS
     /// <summary>
     /// Extension methods for Unity.Collections native containers
     /// </summary>
+    [BurstCompile]
     public static class NativeListExtensions
     {
         /// <summary>

--- a/Assets/Scripts/Core/ECS/PlaySimWorldManager.cs
+++ b/Assets/Scripts/Core/ECS/PlaySimWorldManager.cs
@@ -223,50 +223,50 @@ namespace MarbleMaker.Core.ECS
             var moduleLogicGroup = playSimWorld.GetOrCreateSystemManaged<ModuleLogicGroup>();
             
             // InputActionGroup systems (applies queued click/tap events)
-            var interactApplySystem = playSimWorld.GetOrCreateSystem<InteractApplySystem>();
-            var seedSpawnerSystem = playSimWorld.GetOrCreateSystem<SeedSpawnerSystem>();
+            var interactApplySystem = playSimWorld.Unmanaged.GetOrCreateSystem<InteractApplySystem>();
+            var seedSpawnerSystem = playSimWorld.Unmanaged.GetOrCreateSystem<SeedSpawnerSystem>();
             inputActionGroup.AddSystemToUpdateList(interactApplySystem);
             inputActionGroup.AddSystemToUpdateList(seedSpawnerSystem);
             
             // MotionGroup systems (pure data jobs - marble integration, collision)
-            var marbleIntegrateSystem = playSimWorld.GetOrCreateSystem<MarbleIntegrateSystem>();
-            var collisionDetectSystem = playSimWorld.GetOrCreateSystem<CollisionDetectSystem>();
-            var debrisCompactionSystem = playSimWorld.GetOrCreateSystem<DebrisCompactionSystem>();
+            var marbleIntegrateSystem = playSimWorld.Unmanaged.GetOrCreateSystem<MarbleIntegrateSystem>();
+            var collisionDetectSystem = playSimWorld.Unmanaged.GetOrCreateSystem<CollisionDetectSystem>();
+            var debrisCompactionSystem = playSimWorld.Unmanaged.GetOrCreateSystem<DebrisCompactionSystem>();
             motionGroup.AddSystemToUpdateList(marbleIntegrateSystem);
             motionGroup.AddSystemToUpdateList(collisionDetectSystem);
             motionGroup.AddSystemToUpdateList(debrisCompactionSystem);
             
             // ModuleLogicGroup systems (state machines for splitters, collectors, cannons, lifts)
             // Goal systems (run first)
-            var goalPadInitializationSystem = playSimWorld.GetOrCreateSystem<GoalPadInitializationSystem>();
-            var goalDetectionSystem = playSimWorld.GetOrCreateSystem<GoalDetectionSystem>();
-            var goalPadSystem = playSimWorld.GetOrCreateSystem<GoalPadSystem>();
+            var goalPadInitializationSystem = playSimWorld.Unmanaged.GetOrCreateSystem<GoalPadInitializationSystem>();
+            var goalDetectionSystem = playSimWorld.Unmanaged.GetOrCreateSystem<GoalDetectionSystem>();
+            var goalPadSystem = playSimWorld.Unmanaged.GetOrCreateSystem<GoalPadSystem>();
             moduleLogicGroup.AddSystemToUpdateList(goalPadInitializationSystem);
             moduleLogicGroup.AddSystemToUpdateList(goalDetectionSystem);
             moduleLogicGroup.AddSystemToUpdateList(goalPadSystem);
             
             // Lift systems
-            var liftInitializationSystem = playSimWorld.GetOrCreateSystem<LiftInitializationSystem>();
-            var liftLoadingSystem = playSimWorld.GetOrCreateSystem<LiftLoadingSystem>();
-            var liftStepSystem = playSimWorld.GetOrCreateSystem<LiftStepSystem>();
+            var liftInitializationSystem = playSimWorld.Unmanaged.GetOrCreateSystem<LiftInitializationSystem>();
+            var liftLoadingSystem = playSimWorld.Unmanaged.GetOrCreateSystem<LiftLoadingSystem>();
+            var liftStepSystem = playSimWorld.Unmanaged.GetOrCreateSystem<LiftStepSystem>();
             moduleLogicGroup.AddSystemToUpdateList(liftInitializationSystem);
             moduleLogicGroup.AddSystemToUpdateList(liftLoadingSystem);
             moduleLogicGroup.AddSystemToUpdateList(liftStepSystem);
             
             // Splitter systems
-            var splitterInputDetectionSystem = playSimWorld.GetOrCreateSystem<SplitterInputDetectionSystem>();
-            var splitterLogicSystem = playSimWorld.GetOrCreateSystem<SplitterLogicSystem>();
+            var splitterInputDetectionSystem = playSimWorld.Unmanaged.GetOrCreateSystem<SplitterInputDetectionSystem>();
+            var splitterLogicSystem = playSimWorld.Unmanaged.GetOrCreateSystem<SplitterLogicSystem>();
             moduleLogicGroup.AddSystemToUpdateList(splitterInputDetectionSystem);
             moduleLogicGroup.AddSystemToUpdateList(splitterLogicSystem);
             
             // Collector systems
-            var collectorEnqueueSystem = playSimWorld.GetOrCreateSystem<CollectorEnqueueSystem>();
-            var collectorDequeueSystem = playSimWorld.GetOrCreateSystem<CollectorDequeueSystem>();
+            var collectorEnqueueSystem = playSimWorld.Unmanaged.GetOrCreateSystem<CollectorEnqueueSystem>();
+            var collectorDequeueSystem = playSimWorld.Unmanaged.GetOrCreateSystem<CollectorDequeueSystem>();
             moduleLogicGroup.AddSystemToUpdateList(collectorEnqueueSystem);
             moduleLogicGroup.AddSystemToUpdateList(collectorDequeueSystem);
             
             // Runtime spawning system (runs last)
-            var runtimeMarbleSpawnerSystem = playSimWorld.GetOrCreateSystem<RuntimeMarbleSpawnerSystem>();
+            var runtimeMarbleSpawnerSystem = playSimWorld.Unmanaged.GetOrCreateSystem<RuntimeMarbleSpawnerSystem>();
             moduleLogicGroup.AddSystemToUpdateList(runtimeMarbleSpawnerSystem);
         }
         

--- a/Assets/Scripts/Core/ECS/SeedSpawnerSystem.cs
+++ b/Assets/Scripts/Core/ECS/SeedSpawnerSystem.cs
@@ -101,13 +101,13 @@ namespace MarbleMaker.Core.ECS
             
             // Set initial position at cell center
             var cellCenter = ECSUtils.CellIndexToPosition(spawner.spawnPosition);
-            ecb.SetComponent(marbleEntity, cellCenter);
+            ecb.SetComponent(marbleEntity, new TranslationFP(cellCenter));
             
             // Set initial velocity to zero
-            ecb.SetComponent(marbleEntity, Fixed32.ZERO);
+            ecb.SetComponent(marbleEntity, new VelocityFP(Fixed32x3.Zero));
             
             // Set initial acceleration to zero (will be calculated by physics system)
-            ecb.SetComponent(marbleEntity, Fixed32.ZERO);
+            ecb.SetComponent(marbleEntity, new AccelerationFP(Fixed32x3.Zero));
             
             // Set initial cell index
             ecb.SetComponent(marbleEntity, new CellIndex(spawner.spawnPosition));
@@ -171,13 +171,13 @@ namespace MarbleMaker.Core.ECS
             
             // Set initial position at cell center
             var cellCenter = ECSUtils.CellIndexToPosition(cellPosition);
-            ecb.SetComponent(marbleEntity, cellCenter);
+            ecb.SetComponent(marbleEntity, new TranslationFP(cellCenter));
             
             // Set initial velocity
-            ecb.SetComponent(marbleEntity, initialVelocity);
+            ecb.SetComponent(marbleEntity, new VelocityFP(initialVelocity));
             
             // Set initial acceleration to zero
-            ecb.SetComponent(marbleEntity, Fixed32.ZERO);
+            ecb.SetComponent(marbleEntity, new AccelerationFP(Fixed32x3.Zero));
             
             // Set initial cell index
             ecb.SetComponent(marbleEntity, new CellIndex(cellPosition));


### PR DESCRIPTION
## Summary
- extend `GoalPad`, `CollectorState` and `SplitterState` data
- expose `CellIndex.xyz` and constructor
- mark utilities with `[BurstCompile]`
- allow lookup caches to be mutated and fix sorting call
- fix component usage in marble spawn system
- update system creation for unmanaged systems
- replace invalid hash call and schedule collision job correctly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876bbbae7488330ba4dbdafe2b7346b